### PR TITLE
fix: Use ModelScope as the AI model provider

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,8 @@
-import { pipeline, cos_sim, Pipeline } from '@xenova/transformers';
+import { pipeline, cos_sim, Pipeline, env } from '@xenova/transformers';
+
+// Set the remote host to ModelScope and define the path template
+env.remoteHost = 'https://modelscope.cn';
+env.remotePathTemplate = 'api/v1/models/{model_id}/repo?Revision={revision}&FilePath={path}';
 
 /**
  * A singleton class to manage and provide a single instance of the feature-extraction pipeline.


### PR DESCRIPTION
This commit configures the `@xenova/transformers` library to download models from ModelScope instead of the default Hugging Face hub.

This change is necessary to ensure that the AI models can be reliably loaded for users in mainland China, resolving potential network access issues.