### PR TITLE
fix: Load quantized version of local AI model

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -16,7 +16,8 @@ class PipelineSingleton {
     if (this.instance === null) {
       // Load the model from the local path /public/models/all-MiniLM-L6-v2/
       // The path is relative to the public directory.
-      this.instance = pipeline('feature-extraction', '/models/all-MiniLM-L6-v2');
+      // We explicitly tell the pipeline to load the quantized version.
+      this.instance = pipeline('feature-extraction', '/models/all-MiniLM-L6-v2', { quantized: true });
     }
     return this.instance;
   }


### PR DESCRIPTION
This commit updates the AI service to correctly load the quantized version of the local model.

By adding the `{ quantized: true }` option to the `pipeline()` call in `ai.ts`, the library is now instructed to look for the `model_quantized.onnx` file, resolving the model loading failure.