### PR TITLE
fix: Add robust local-only AI model loading

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,4 +1,8 @@
-import { pipeline, cos_sim, Pipeline } from '@xenova/transformers';
+import { pipeline, cos_sim, Pipeline, env } from '@xenova/transformers';
+
+// Configure transformers.js to use local models only.
+env.allowLocalModels = true;
+env.allowRemoteModels = false;
 
 /**
  * A singleton class to manage and provide a single instance of the feature-extraction pipeline.


### PR DESCRIPTION
This commit fixes the AI model loading failure by robustly configuring the `@xenova/transformers` library for local-only model loading.

It explicitly disables remote model downloads (`env.allowRemoteModels = false`) and enables local models (`env.allowLocalModels = true`). This change, combined with the existing configuration to use the quantized version, ensures the app does not attempt any network requests for model files and correctly loads the quantized model from the local `/public/models` directory.

This resolves the bug where the identifier page would get stuck in a loading state.