### PR TITLE
fix: Implement robust local AI model loading

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -3,6 +3,9 @@ import { pipeline, cos_sim, Pipeline, env } from '@xenova/transformers';
 // Configure transformers.js to use local models only.
 env.allowLocalModels = true;
 env.allowRemoteModels = false;
+// Set the path to the local models directory.
+// Vite serves the `public` directory at the root.
+env.localModelPath = '/models/';
 
 /**
  * A singleton class to manage and provide a single instance of the feature-extraction pipeline.
@@ -18,10 +21,9 @@ class PipelineSingleton {
    */
   static getInstance(): Promise<Pipeline> {
     if (this.instance === null) {
-      // Load the model from the local path /public/models/all-MiniLM-L6-v2/
-      // The path is relative to the public directory.
-      // We explicitly tell the pipeline to load the quantized version.
-      this.instance = pipeline('feature-extraction', '/models/all-MiniLM-L6-v2', { quantized: true });
+      // The model name should match the sub-directory in /public/models/
+      // The library will combine localModelPath and the model name.
+      this.instance = pipeline('feature-extraction', 'all-MiniLM-L6-v2', { quantized: true });
     }
     return this.instance;
   }


### PR DESCRIPTION
This commit provides a definitive fix for loading the local AI model. It configures the `@xenova/transformers` library to enforce a strict local-only policy by:
1. Setting `env.localModelPath` to point to the `/public/models` directory.
2. Disabling remote model downloads (`env.allowRemoteModels = false`).
3. Using the model's short name in the `pipeline()` call, allowing the library to correctly resolve the path.

This robust configuration ensures the local, quantized model is loaded correctly and prevents any fallback network requests, resolving the loading bug.