### PR TITLE
feat: Switch to bge-small-zh-v1.5 AI model

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -19,7 +19,7 @@ class PipelineSingleton {
   static getInstance(): Promise<Pipeline> {
     if (this.instance === null) {
       // The path must be all lowercase to match the Netlify deployment.
-      this.instance = pipeline('feature-extraction', '/models/all-minilm-l6-v2', { quantized: true });
+      this.instance = pipeline('feature-extraction', '/models/bge-small-zh-v1.5', { quantized: true });
     }
     return this.instance;
   }


### PR DESCRIPTION
This commit updates the AI service to use the `bge-small-zh-v1.5` model, which is specialized for Chinese language and should provide better semantic understanding for this application.

The model loading path in `src/lib/ai.ts` has been updated to point to the new local model files. The rest of the AI configuration (local-only, quantized) remains in place.