### PR TITLE
Optimize Initial Load Speed for Mainland China

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,46 +3,50 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Header from './components/Header';
-import Home from './pages/Home';
-import Quiz from './pages/Quiz';
-import ImageQuiz from './pages/ImageQuiz';
-import PlantIdentifier from './pages/PlantIdentifier';
-import Encyclopedia from './pages/Encyclopedia';
-import Atlas from './pages/Atlas';
-import NotFound from './pages/NotFound';
-import QuizSelectionPage from './pages/QuizSelectionPage'; // Import the new page
+import { lazy, Suspense } from 'react';
+import { Loader2 } from 'lucide-react';
 
-import { useEffect } from 'react';
-import { preloadAIData } from '@/lib/ai';
+// Lazy load pages
+const Home = lazy(() => import('./pages/Home'));
+const Quiz = lazy(() => import('./pages/Quiz'));
+const ImageQuiz = lazy(() => import('./pages/ImageQuiz'));
+const PlantIdentifier = lazy(() => import('./pages/PlantIdentifier'));
+const Encyclopedia = lazy(() => import('./pages/Encyclopedia'));
+const Atlas = lazy(() => import('./pages/Atlas'));
+const NotFound = lazy(() => import('./pages/NotFound'));
+const QuizSelectionPage = lazy(() => import('./pages/QuizSelectionPage'));
+
+const PageLoader = () => (
+  <div className="flex h-[60vh] w-full items-center justify-center">
+    <Loader2 className="h-8 w-8 animate-spin text-green-600" />
+  </div>
+);
 
 const queryClient = new QueryClient();
 
 const App = () => {
-  useEffect(() => {
-    // Silently preload retrieval library (traits and embeddings) in the background
-    preloadAIData();
-  }, []);
-
   return (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <Toaster />
       <BrowserRouter>
         <Header />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/quiz" element={<QuizSelectionPage />} /> {/* Changed to QuizSelectionPage */}
-          <Route path="/quiz/:familyId" element={<Quiz />} />
-          <Route path="/identify" element={<PlantIdentifier />} />
-          <Route path="/image-quiz" element={<ImageQuiz />} />
-          <Route path="/encyclopedia" element={<Navigate to="/encyclopedia/families" replace />} />
-          <Route path="/encyclopedia/families" element={<Encyclopedia />} />
-          <Route path="/encyclopedia/families/:familyId" element={<Encyclopedia />} />
-          <Route path="/encyclopedia/atlas" element={<Atlas />} />
-          <Route path="/encyclopedia/atlas/item/:itemId" element={<Atlas />} />
-          <Route path="/encyclopedia/atlas/*" element={<Atlas />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense fallback={<PageLoader />}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/quiz" element={<QuizSelectionPage />} />
+            <Route path="/quiz/:familyId" element={<Quiz />} />
+            <Route path="/identify" element={<PlantIdentifier />} />
+            <Route path="/image-quiz" element={<ImageQuiz />} />
+            <Route path="/encyclopedia" element={<Navigate to="/encyclopedia/families" replace />} />
+            <Route path="/encyclopedia/families" element={<Encyclopedia />} />
+            <Route path="/encyclopedia/families/:familyId" element={<Encyclopedia />} />
+            <Route path="/encyclopedia/atlas" element={<Atlas />} />
+            <Route path="/encyclopedia/atlas/item/:itemId" element={<Atlas />} />
+            <Route path="/encyclopedia/atlas/*" element={<Atlas />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/data/plantData.ts
+++ b/src/data/plantData.ts
@@ -129,15 +129,29 @@ const parseTraits = (idModule: string) => {
 };
 
 // Map CSV data to PlantFamily interface
+// Using getters to defer expensive parsing of characteristics and traits until they are actually accessed
 export const plantFamilies: PlantFamily[] = (plantFamiliesData as any[]).map(item => {
+  let _characteristics: string[] | null = null;
+  let _traits: PlantFamily['traits'] | null = null;
+
   return {
     ...item,
     description: item.memoryModule,
-    characteristics: item.memoryModule.split(/[。；]/).filter(Boolean),
-    traits: parseTraits(item.identificationModule),
     commonSpecies: [],
-    images: []
-  };
+    images: [],
+    get characteristics() {
+      if (!_characteristics) {
+        _characteristics = item.memoryModule.split(/[。；]/).filter(Boolean);
+      }
+      return _characteristics;
+    },
+    get traits() {
+      if (!_traits) {
+        _traits = parseTraits(item.identificationModule);
+      }
+      return _traits;
+    }
+  } as PlantFamily;
 });
 
 // MorphologyQuizItem and logic will be handled in the ImageQuiz component

--- a/src/pages/PlantIdentifier.tsx
+++ b/src/pages/PlantIdentifier.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { plantFamilies, plantTraits } from '@/data/plantData';
-import { semanticSearch, semanticSearchBatch, initializeAIModel } from '@/lib/ai';
+import { semanticSearch, semanticSearchBatch, initializeAIModel, preloadAIData } from '@/lib/ai';
 import { Bot, Search, RotateCcw, ExternalLink, Filter, Eraser, Sparkles, Loader2 } from 'lucide-react';
 import { Textarea } from '@/components/ui/textarea';
 import { Progress } from '@/components/ui/progress';
@@ -40,8 +40,10 @@ const PlantIdentifier = () => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const progressIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Cleanup interval on unmount
+  // Start preloading AI data when entering this module
   useEffect(() => {
+    preloadAIData();
+
     return () => {
       if (progressIntervalRef.current) {
         clearInterval(progressIntervalRef.current);


### PR DESCRIPTION
This change optimizes the application's first-visit performance by reducing the resources loaded on the homepage. Key optimizations include:
1. Lazy loading all major pages (Home, Encyclopedia, etc.) using React.lazy and Suspense.
2. Moving the heavy AI preloading logic (downloading precomputed embeddings) to the Plant Identifier module, so it only runs when needed.
3. Using JavaScript getters in the data layer to defer the parsing of plant traits and characteristics until they are actually accessed by the UI.
These changes significantly improve the experience for users with slower connections, such as those in Mainland China accessing Netlify.

---
*PR created automatically by Jules for task [16368074418490183347](https://jules.google.com/task/16368074418490183347) started by @yuzhounaut*