### PR TITLE
Lower identification module similarity threshold

### DIFF
--- a/src/pages/PlantIdentifier.tsx
+++ b/src/pages/PlantIdentifier.tsx
@@ -137,8 +137,8 @@ const PlantIdentifier = () => {
         });
 
         bestScoresPerFamily.forEach((data, familyId) => {
-          // To implement AND logic, each segment must have a score >= 0.8
-          if (data.score >= 0.8) {
+          // To implement AND logic, each segment must have a score >= 0.66
+          if (data.score >= 0.66) {
             if (!familyScores.has(familyId)) {
               familyScores.set(familyId, { validSegmentCount: 0, totalScore: 0, matches: [] });
             }
@@ -152,7 +152,7 @@ const PlantIdentifier = () => {
 
       const finalResults: AIIdentificationResultItem[] = [];
       familyScores.forEach((data, familyId) => {
-        // Must match ALL query segments with score >= 0.8
+        // Must match ALL query segments with score >= 0.66
         if (data.validSegmentCount === querySegments.length) {
           const avgScore = data.totalScore / querySegments.length;
           const familyInfo = plantFamilies.find(pf => pf.id === familyId);


### PR DESCRIPTION
Lowers the similarity score matching threshold in the Intelligent Identifier module to ensure synonymous terms with slight character differences correctly resolve to matching plant traits.

---
*PR created automatically by Jules for task [13999498801777109806](https://jules.google.com/task/13999498801777109806) started by @yuzhounaut*