### PR TITLE
Add site analytics and visitor counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
   <meta name="referrer" content="no-referrer" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NXP9QYWJLN"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-NXP9QYWJLN');
+  </script>
 </head>
 
 <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Header from './components/Header';
+import Footer from './components/Footer';
 import Home from './pages/Home';
 import Quiz from './pages/Quiz';
 import ImageQuiz from './pages/ImageQuiz';
@@ -29,20 +30,23 @@ const App = () => {
       <Toaster />
       <BrowserRouter>
         <Header />
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/quiz" element={<QuizSelectionPage />} /> {/* Changed to QuizSelectionPage */}
-          <Route path="/quiz/:familyId" element={<Quiz />} />
-          <Route path="/identifier" element={<PlantIdentifier />} />
-          <Route path="/image-quiz" element={<ImageQuiz />} />
-          <Route path="/encyclopedia" element={<Navigate to="/encyclopedia/families" replace />} />
-          <Route path="/encyclopedia/families" element={<Encyclopedia />} />
-          <Route path="/encyclopedia/families/:familyId" element={<Encyclopedia />} />
-          <Route path="/encyclopedia/atlas" element={<Atlas />} />
-          <Route path="/encyclopedia/atlas/item/:itemId" element={<Atlas />} />
-          <Route path="/encyclopedia/atlas/*" element={<Atlas />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <div className="flex flex-col min-h-screen">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/quiz" element={<QuizSelectionPage />} /> {/* Changed to QuizSelectionPage */}
+            <Route path="/quiz/:familyId" element={<Quiz />} />
+            <Route path="/identifier" element={<PlantIdentifier />} />
+            <Route path="/image-quiz" element={<ImageQuiz />} />
+            <Route path="/encyclopedia" element={<Navigate to="/encyclopedia/families" replace />} />
+            <Route path="/encyclopedia/families" element={<Encyclopedia />} />
+            <Route path="/encyclopedia/families/:familyId" element={<Encyclopedia />} />
+            <Route path="/encyclopedia/atlas" element={<Atlas />} />
+            <Route path="/encyclopedia/atlas/item/:itemId" element={<Atlas />} />
+            <Route path="/encyclopedia/atlas/*" element={<Atlas />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+          <Footer />
+        </div>
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+const Footer = () => {
+  useEffect(() => {
+    // 动态加载不蒜子脚本
+    const script = document.createElement('script');
+    script.src = '//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js';
+    script.async = true;
+    document.body.appendChild(script);
+
+    return () => {
+      // 组件卸载时移除脚本
+      if (document.body.contains(script)) {
+        document.body.removeChild(script);
+      }
+    };
+  }, []);
+
+  return (
+    <footer className="w-full border-t border-border bg-background/95 py-6 mt-auto">
+      <div className="container mx-auto px-4 text-center text-muted-foreground text-sm">
+        <p className="mb-2">© {new Date().getFullYear()} ZhiShi - 植识. All rights reserved.</p>
+        <div className="flex items-center justify-center space-x-2">
+          <span id="busuanzi_container_site_pv" style={{ display: 'none' }}>
+            本站总访问量：<span id="busuanzi_value_site_pv" className="font-semibold text-primary"></span> 次
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION
This PR fulfills the user's request to integrate website analytics. 

**Changes:**
1. Added Google Analytics 4 (Measurement ID: `G-NXP9QYWJLN`) to the `index.html` file to track overall site traffic anonymously, fulfilling the requirement to have a backend overview without managing our own database.
2. Created a persistent `Footer.tsx` component that dynamically loads the "Busuanzi" (不蒜子) script in a `useEffect` hook. This approach ensures the non-React script loads properly within our React SPA architecture.
3. Added the visitor counter UI element ("本站总访问量：XXX 次") to the footer as requested.
4. Integrated the new Footer into the main routing layout in `App.tsx`.

---
*PR created automatically by Jules for task [7367772090717386241](https://jules.google.com/task/7367772090717386241) started by @yuzhounaut*